### PR TITLE
Support enum type. add .gitignore file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+vendor
+composer.lock

--- a/cli/main.php
+++ b/cli/main.php
@@ -12,6 +12,7 @@ function dump($input, $output)
     );
 
     $conn = \Doctrine\DBAL\DriverManager::getConnection($connectionParams, $config);
+    $conn->getDatabasePlatform()->registerDoctrineTypeMapping('enum', 'string');
 
     $sm = $conn->getSchemaManager();
 


### PR DESCRIPTION
http://doctrine-orm.readthedocs.io/projects/doctrine-orm/en/latest/cookbook/mysql-enums.html#solution-1-mapping-to-varchars

In this way, the dump can work well with enum field.
